### PR TITLE
Modify. WiggleBorder- childrenSize를 0으로 자꾸 설정하는 코드 제거

### DIFF
--- a/components/WiggleBorder.tsx
+++ b/components/WiggleBorder.tsx
@@ -171,12 +171,6 @@ const WiggleBorder: React.FC<IWiggleBorderProps> = ({
       setChildrenSize({ width: width, height: height });
   };
 
-  // children 내용이 변경될 때마다 레이아웃 재계산을 위한 effect
-  useEffect(() => {
-    // children이 변경되면 childrenSize를 초기화하여 다시 측정하도록 함
-    setChildrenSize({ width: 0, height: 0 });
-  }, [children]);
-
   // 실제 렌더링에 사용할 크기 계산 (여백을 뺀 실제 border 영역)
   const actualWidth =
     typeof width === "number"


### PR DESCRIPTION
## 🛠 주요 변경 사항
WiggleBorder component의 height가 이상한 이슈가 있어서, 
해당 부분 코드를 조정하였습니다.ᐟ

children이 변경될 때마다 레이아웃 사이즈를 재계산하는 것이 아니라 0으로 세팅하는 것이 원인어었던 것으로 확인됩니다!
